### PR TITLE
Add available values for Select RT::CustomField

### DIFF
--- a/lib/RT/Extension/REST2/Util.pm
+++ b/lib/RT/Extension/REST2/Util.pm
@@ -90,6 +90,18 @@ sub serialize_record {
         }
     }
 
+    # Add available values for Select RT::CustomField
+    if (ref($record) eq 'RT::CustomField' && $record->Type eq 'Select') {
+        my $values = $record->Values;
+        while (my $val = $values->Next) {
+            if (exists $data{Values}) {
+                push @{$data{Values}}, $val->Name;
+            } else {
+                $data{Values} = [ $val->Name ];
+            }
+        }
+    }
+
     # Replace UIDs with object placeholders
     for my $uid (grep ref eq 'SCALAR', values %data) {
         $uid = expand_uid($uid);


### PR DESCRIPTION
This small patch allows requests for a CustomField (GET /customfield/:id) to return a new JSON property, "Values:" as an array of all possible values for RT::Customfield of type Select.