### PR TITLE
Quick and dirty support for message attachments

### DIFF
--- a/lib/RT/Extension/REST2/Resource/Message.pm
+++ b/lib/RT/Extension/REST2/Resource/Message.pm
@@ -92,7 +92,7 @@ sub add_message {
             $MIME->attach(
                 Type => $$attachment{ContentType},
                 Filename => $$attachment{Filename},
-                Data => MIME::Base64::decode_base64($$attachment{Content})
+                Data => RT::I18N::IsTextualContentType($$attachment{ContentType}) ? $$attachment{Content} : MIME::Base64::decode_base64($$attachment{Content})
             );
         }
     }

--- a/lib/RT/Extension/REST2/Resource/Message.pm
+++ b/lib/RT/Extension/REST2/Resource/Message.pm
@@ -69,6 +69,34 @@ sub add_message {
         Subject   => $args{Subject},
     );
 
+    if (defined $args{Attachments} && ref $args{Attachments} eq 'ARRAY' && scalar(@{$args{Attachments}}) > 0) {
+        $MIME->make_multipart;
+
+        foreach my $attachment (@{$args{Attachments}}) {
+            if (!$$attachment{ContentType}) {
+                return error_as_json(
+                    $self->response,
+                    \400, "ContentType is a required attachment field");
+            }
+
+            if (!$$attachment{Filename}) {
+                $$attachment{Filename} = "unknown.dat";
+            }
+
+            if (!$$attachment{Content}) {
+                return error_as_json(
+                    $self->response,
+                    \400, "Content is a required attachment field");
+            }
+
+            $MIME->attach(
+                Type => $$attachment{ContentType},
+                Filename => $$attachment{Filename},
+                Data => MIME::Base64::decode_base64($$attachment{Content})
+            );
+        }
+    }
+
     my ( $Trans, $msg, $TransObj ) ;
 
     if ($self->type eq 'correspond') {


### PR DESCRIPTION
The change adds simple support for message attachments through a new JSON array parameter called Attachments.