### PR TITLE
Add group members user memberships

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -37,6 +37,7 @@ lib/RT/Extension/REST2/Resource/CustomRole.pm
 lib/RT/Extension/REST2/Resource/CustomRoles.pm
 lib/RT/Extension/REST2/Resource/Group.pm
 lib/RT/Extension/REST2/Resource/Groups.pm
+lib/RT/Extension/REST2/Resource/Members.pm
 lib/RT/Extension/REST2/Resource/Message.pm
 lib/RT/Extension/REST2/Resource/Queue.pm
 lib/RT/Extension/REST2/Resource/Queues.pm
@@ -56,6 +57,7 @@ lib/RT/Extension/REST2/Resource/TicketsBulk.pm
 lib/RT/Extension/REST2/Resource/Transaction.pm
 lib/RT/Extension/REST2/Resource/Transactions.pm
 lib/RT/Extension/REST2/Resource/User.pm
+lib/RT/Extension/REST2/Resource/UserGroups.pm
 lib/RT/Extension/REST2/Resource/Users.pm
 lib/RT/Extension/REST2/Util.pm
 Makefile.PL
@@ -66,6 +68,7 @@ t/asset-customfields.t
 t/assets.t
 t/catalogs.t
 t/conflict.t
+t/group-members.t
 t/lib/RT/Extension/REST2/Test.pm.in
 t/not_found.t
 t/organization.t
@@ -80,4 +83,5 @@ t/tickets-bulk.t
 t/tickets.t
 t/transactions.t
 t/user-customfields.t
+t/user-memberships.t
 TODO

--- a/README
+++ b/README
@@ -398,11 +398,11 @@ USAGE
 
         GET /user/:id
         GET /user/:name
-            retrieve a user by numeric id or username
+            retrieve a user by numeric id or username (including its memberships and whether it is disabled)
 
         PUT /user/:id
         PUT /user/:name
-            update a user's metadata; provide JSON content
+            update a user's metadata (including its Disabled status); provide JSON content
 
         DELETE /user/:id
         DELETE /user/:name
@@ -417,11 +417,63 @@ USAGE
         POST /groups
             search for groups using L</JSON searches> syntax
 
+        POST /group
+            create a (user defined) group; provide JSON content
+
         GET /group/:id
-            retrieve a group (including its members)
+            retrieve a group (including its members and whether it is disabled)
+
+        PUT /group/:id
+            update a groups's metadata (including its Disabled status); provide JSON content
+
+        DELETE /group/:id
+            disable group
 
         GET /group/:id/history
             retrieve list of transactions for group
+
+   User Memberships
+        GET /user/:id/groups
+        GET /user/:name/groups
+            retrieve list of groups which a user is a member of
+
+        PUT /user/:id/groups
+        PUT /user/:name/groups
+            add a user to groups; provide a JSON array of groups ids
+
+        DELETE /user/:id/group/:id
+        DELETE /user/:name/group/:id
+            remove a user from a group
+
+        DELETE /user/:id/groups
+        DELETE /user/:name/groups
+            remove a user from all groups
+
+   Group Members
+        GET /group/:id/members
+            retrieve list of direct members of a group
+
+        GET /group/:id/deepmembers
+            retrieve list of direct and recursive members of a group
+
+        GET /group/:id/groupmembers
+        GET /group/:id/groupmembers?recursively=0
+            retrieve list of group members of a group, by default recursively
+            or only direct group members passing parameter recursively=0
+
+        GET /group/:id/usermembers
+        GET /group/:id/usermembers?recursively=0
+            retrieve list of user members of a group, by default recursively
+            or only direct user members passing parameter recursively=0
+
+        PUT /group/:id/members
+            add members to a group; provide a JSON array of principal ids
+
+        DELETE /group/:id/member/:id
+            remove a member from a group
+
+        DELETE /group/:id/members
+            remove all members from a group
 
    Custom Fields
         GET /customfields?query=<JSON>

--- a/lib/RT/Extension/REST2.pm
+++ b/lib/RT/Extension/REST2.pm
@@ -440,11 +440,11 @@ Below are some examples using the endpoints above.
 
     GET /user/:id
     GET /user/:name
-        retrieve a user by numeric id or username
+        retrieve a user by numeric id or username (including its memberships and whether it is disabled)
 
     PUT /user/:id
     PUT /user/:name
-        update a user's metadata; provide JSON content
+        update a user's metadata (including its Disabled status); provide JSON content
 
     DELETE /user/:id
     DELETE /user/:name
@@ -460,11 +460,65 @@ Below are some examples using the endpoints above.
     POST /groups
         search for groups using L</JSON searches> syntax
 
+    POST /group
+        create a (user defined) group; provide JSON content
+
     GET /group/:id
-        retrieve a group (including its members)
+        retrieve a group (including its members and whether it is disabled)
+
+    PUT /group/:id
+        update a groups's metadata (including its Disabled status); provide JSON content
+
+    DELETE /group/:id
+        disable group
 
     GET /group/:id/history
         retrieve list of transactions for group
+
+=head3 User Memberships
+
+    GET /user/:id/groups
+    GET /user/:name/groups
+        retrieve list of groups which a user is a member of
+
+    PUT /user/:id/groups
+    PUT /user/:name/groups
+        add a user to groups; provide a JSON array of groups ids
+
+    DELETE /user/:id/group/:id
+    DELETE /user/:name/group/:id
+        remove a user from a group
+
+    DELETE /user/:id/groups
+    DELETE /user/:name/groups
+        remove a user from all groups
+
+=head3 Group Members
+
+    GET /group/:id/members
+        retrieve list of direct members of a group
+
+    GET /group/:id/deepmembers
+        retrieve list of direct and recursive members of a group
+
+    GET /group/:id/groupmembers
+    GET /group/:id/groupmembers?recursively=0
+        retrieve list of group members of a group, by default recursively
+        or only direct group members passing parameter recursively=0
+
+    GET /group/:id/usermembers
+    GET /group/:id/usermembers?recursively=0
+        retrieve list of user members of a group, by default recursively
+        or only direct user members passing parameter recursively=0
+
+    PUT /group/:id/members
+        add members to a group; provide a JSON array of principal ids
+
+    DELETE /group/:id/member/:id
+        remove a member from a group
+
+    DELETE /group/:id/members
+        remove all members from a group
 
 =head3 Custom Fields
 

--- a/lib/RT/Extension/REST2/Resource/Group.pm
+++ b/lib/RT/Extension/REST2/Resource/Group.pm
@@ -45,6 +45,27 @@ sub hypermedia_links {
     my $self = shift;
     my $links = $self->_default_hypermedia_links(@_);
     push @$links, $self->_transaction_history_link;
+
+    if ($self->record->CurrentUserHasRight('AdminGroupMembership')) {
+        my $id = $self->record->id;
+        push @$links,
+            {
+                ref  => 'members',
+                _url => RT::Extension::REST2->base_uri . "/group/$id/members",
+            },
+            {
+                ref  => 'deepmembers',
+                _url => RT::Extension::REST2->base_uri . "/group/$id/deepmembers",
+            },
+            {
+                ref  => 'groupmembers',
+                _url => RT::Extension::REST2->base_uri . "/group/$id/groupmembers",
+            },
+            {
+                ref  => 'usermembers',
+                _url => RT::Extension::REST2->base_uri . "/group/$id/usermembers",
+            };
+    }
     return $links;
 }
 

--- a/lib/RT/Extension/REST2/Resource/Group.pm
+++ b/lib/RT/Extension/REST2/Resource/Group.pm
@@ -34,6 +34,8 @@ sub serialize {
         @{ $self->record->MembersObj->ItemsArrayRef }
     ];
 
+    $data->{Disabled}   = $self->record->PrincipalObj->Disabled;
+
     return $data;
 }
 

--- a/lib/RT/Extension/REST2/Resource/Group.pm
+++ b/lib/RT/Extension/REST2/Resource/Group.pm
@@ -9,6 +9,7 @@ use RT::Extension::REST2::Util qw(expand_uid);
 extends 'RT::Extension::REST2::Resource::Record';
 with 'RT::Extension::REST2::Resource::Record::Readable'
         => { -alias => { serialize => '_default_serialize' } },
+    'RT::Extension::REST2::Resource::Record::Writable',
     'RT::Extension::REST2::Resource::Record::Hypermedia'
         => { -alias => { hypermedia_links => '_default_hypermedia_links' } };
 

--- a/lib/RT/Extension/REST2/Resource/Group.pm
+++ b/lib/RT/Extension/REST2/Resource/Group.pm
@@ -9,6 +9,7 @@ use RT::Extension::REST2::Util qw(expand_uid);
 extends 'RT::Extension::REST2::Resource::Record';
 with 'RT::Extension::REST2::Resource::Record::Readable'
         => { -alias => { serialize => '_default_serialize' } },
+    'RT::Extension::REST2::Resource::Record::DeletableByDisabling',
     'RT::Extension::REST2::Resource::Record::Writable',
     'RT::Extension::REST2::Resource::Record::Hypermedia'
         => { -alias => { hypermedia_links => '_default_hypermedia_links' } };

--- a/lib/RT/Extension/REST2/Resource/Members.pm
+++ b/lib/RT/Extension/REST2/Resource/Members.pm
@@ -1,0 +1,136 @@
+package RT::Extension::REST2::Resource::Members;
+use strict;
+use warnings;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'RT::Extension::REST2::Resource::Collection';
+with 'RT::Extension::REST2::Resource::Role::RequestBodyIsJSON' =>
+  {type => 'ARRAY'};
+
+has 'group' => (
+    is  => 'ro',
+    isa => 'RT::Group',
+);
+
+sub dispatch_rules {
+    Path::Dispatcher::Rule::Regex->new(
+        regex => qr{^/group/(\d+)/(deep|group|user)?members/?$},
+        block => sub {
+            my ($match, $req) = @_;
+            my $group_id = $match->pos(1);
+            my $type = $match->pos(2) || '';
+            my $group = RT::Group->new($req->env->{"rt.current_user"});
+            $group->Load($group_id);
+
+            if ($type eq 'deep') {
+                return {group => $group, collection => $group->DeepMembersObj};
+            } elsif ($type eq 'group') {
+                return {group => $group, collection => $group->GroupMembersObj(Recursively => $req->parameters->{recursively} // 1)};
+            } elsif ($type eq 'user') {
+                return {group => $group, collection => $group->UserMembersObj(Recursively => $req->parameters->{recursively} // 1)};
+            } else {
+                return {group => $group, collection => $group->MembersObj};
+            }
+        },
+    ),
+    Path::Dispatcher::Rule::Regex->new(
+        regex => qr{^/group/(\d+)/member/(\d+)/?$},
+        block => sub {
+            my ($match, $req) = @_;
+            my $group_id = $match->pos(1);
+            my $member_id = $match->pos(2) || '';
+            my $group = RT::Group->new($req->env->{"rt.current_user"});
+            $group->Load($group_id);
+            my $collection = $group->MembersObj;
+            $collection->Limit(FIELD => 'MemberId', VALUE => $member_id);
+            return {group => $group, collection => $collection};
+        },
+    ),
+}
+
+sub forbidden {
+    my $self = shift;
+    return 0 if $self->current_user->HasRight(
+        Right   => "AdminUsers",
+        Object  => RT->System,
+    );
+    return 1;
+}
+
+sub serialize {
+    my $self = shift;
+    my $collection = $self->collection;
+    my @results;
+
+    while (my $item = $collection->Next) {
+        my ($id, $class);
+        if (ref $item eq 'RT::GroupMember' || ref $item eq 'RT::CachedGroupMember') {
+            my $principal = $item->MemberObj;
+            $class = $principal->IsGroup ? 'group' : 'user';
+            $id = $principal->id;
+        } elsif (ref $item eq 'RT::Group') {
+            $class = 'group';
+            $id = $item->id;
+        } else {
+            $class = 'user';
+            $id = $item->id;
+        }
+
+        my $result = {
+            type => $class,
+            id   => $id,
+            _url => RT::Extension::REST2->base_uri . "/$class/$id",
+        };
+        push @results, $result;
+    }
+    return {
+        count       => scalar(@results)         + 0,
+        total       => $collection->CountAll    + 0,
+        per_page    => $collection->RowsPerPage + 0,
+        page        => ($collection->FirstRow / $collection->RowsPerPage) + 1,
+        items       => \@results,
+    };
+}
+
+sub allowed_methods {
+    my @ok = ('GET', 'HEAD', 'DELETE', 'PUT');
+    return \@ok;
+}
+
+sub content_types_accepted {[{'application/json' => 'from_json'}]}
+
+sub delete_resource {
+    my $self = shift;
+    my $collection = $self->collection;
+    while (my $group_member = $collection->Next) {
+        $RT::Logger->info('Delete ' . ($group_member->MemberObj->IsGroup ? 'group' : 'user') . ' ' . $group_member->MemberId . ' from group '.$group_member->GroupId);
+        $group_member->GroupObj->Object->DeleteMember($group_member->MemberId);
+    }
+    return 1;
+}
+
+sub from_json {
+    my $self   = shift;
+    my $params = JSON::decode_json($self->request->content);
+    my $group = $self->group;
+
+    my $method = $self->request->method;
+    my @results;
+    if ($method eq 'PUT') {
+        for my $param (@$params) {
+            if ($param =~ /^\d+$/) {
+                push @results, $group->AddMember($param);
+            } else {
+                push @results, [0, 'You should provide principal id for each member to add'];
+            }
+        }
+    }
+    $self->response->body(JSON::encode_json(\@results));
+    return;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/RT/Extension/REST2/Resource/Record/Writable.pm
+++ b/lib/RT/Extension/REST2/Resource/Record/Writable.pm
@@ -54,6 +54,7 @@ sub update_record {
 
     push @results, $self->_update_custom_fields($data->{CustomFields});
     push @results, $self->_update_role_members($data);
+    push @results, $self->_update_disabled($data->{Disabled});
 
     # XXX TODO: Figure out how to return success/failure?  Core RT::Record's
     # ->Update will need to be replaced or improved.
@@ -244,6 +245,22 @@ sub _update_role_members {
             }
         }
     }
+
+    return @results;
+}
+
+sub _update_disabled {
+    my $self = shift;
+    my $data = shift;
+    my @results;
+
+    my $record = $self->record;
+    return unless defined $data and $data =~ /^[01]$/;
+
+    return unless $record->can('SetDisabled');
+
+    my ($ok, $msg) = $record->SetDisabled($data);
+    push @results, $msg;
 
     return @results;
 }

--- a/lib/RT/Extension/REST2/Resource/Record/Writable.pm
+++ b/lib/RT/Extension/REST2/Resource/Record/Writable.pm
@@ -284,7 +284,8 @@ sub create_record {
         }
     }
 
-    my ($ok, @rest) = $record->Create(%args);
+    my $method = $record->isa('RT::Group') ? 'CreateUserDefinedGroup' : 'Create';
+    my ($ok, @rest) = $record->$method(%args);
 
     if ($ok && $cfs) {
         $self->_update_custom_fields($cfs);

--- a/lib/RT/Extension/REST2/Resource/User.pm
+++ b/lib/RT/Extension/REST2/Resource/User.pm
@@ -60,6 +60,22 @@ sub hypermedia_links {
     my $self = shift;
     my $links = $self->_default_hypermedia_links(@_);
     push @$links, $self->_transaction_history_link;
+
+    if (
+        ($self->current_user->HasRight(
+            Right => "ModifyOwnMembership",
+            Object => RT->System)
+         && $self->current_user->id == $self->record->id)
+        || $self->current_user->HasRight(
+            Right => 'AdminGroupMembership',
+            Object => RT->System)
+    ) {
+        my $id = $self->record->id;
+        push @$links, {
+            ref  => 'memberships',
+            _url => RT::Extension::REST2->base_uri . "/user/$id/groups",
+        };
+    }
     return $links;
 }
 

--- a/lib/RT/Extension/REST2/Resource/User.pm
+++ b/lib/RT/Extension/REST2/Resource/User.pm
@@ -4,6 +4,7 @@ use warnings;
 
 use Moose;
 use namespace::autoclean;
+use RT::Extension::REST2::Util qw(expand_uid);
 
 extends 'RT::Extension::REST2::Resource::Record';
 with (
@@ -40,6 +41,10 @@ around 'serialize' => sub {
     my $data = $self->$orig(@_);
     $data->{Privileged} = $self->record->Privileged ? 1 : 0;
     $data->{Disabled}   = $self->record->PrincipalObj->Disabled;
+    $data->{Memberships} = [
+        map { expand_uid($_->UID) }
+        @{ $self->record->OwnGroups(Recursively => 0)->ItemsArrayRef }
+    ];
     return $data;
 };
 

--- a/lib/RT/Extension/REST2/Resource/UserGroups.pm
+++ b/lib/RT/Extension/REST2/Resource/UserGroups.pm
@@ -23,7 +23,7 @@ sub dispatch_rules {
             my $user = RT::User->new($req->env->{"rt.current_user"});
             $user->Load($user_id);
 
-            return {user => $user, collection => $user->OwnGroups(Recursively => $req->parameters->{recursively} // 1)};
+            return {user => $user, collection => $user->OwnGroups};
         },
     ),
     Path::Dispatcher::Rule::Regex->new(

--- a/lib/RT/Extension/REST2/Resource/UserGroups.pm
+++ b/lib/RT/Extension/REST2/Resource/UserGroups.pm
@@ -43,10 +43,14 @@ sub dispatch_rules {
 
 sub forbidden {
     my $self = shift;
-    return 0 if $self->current_user->HasRight(
-        Right   => "ModifyOwnMembership",
-        Object  => RT->System,
-    );
+    return 0 if
+        ($self->current_user->HasRight(
+            Right  => "ModifyOwnMembership",
+            Object => RT->System,
+        ) && $self->current_user->id == $self->user->id) ||
+        $self->current_user->HasRight(
+            Right  => 'AdminGroupMembership',
+            Object => RT->System);
     return 1;
 }
 

--- a/lib/RT/Extension/REST2/Resource/UserGroups.pm
+++ b/lib/RT/Extension/REST2/Resource/UserGroups.pm
@@ -44,7 +44,7 @@ sub dispatch_rules {
 sub forbidden {
     my $self = shift;
     return 0 if $self->current_user->HasRight(
-        Right   => "AdminUsers",
+        Right   => "ModifyOwnMembership",
         Object  => RT->System,
     );
     return 1;

--- a/lib/RT/Extension/REST2/Resource/UserGroups.pm
+++ b/lib/RT/Extension/REST2/Resource/UserGroups.pm
@@ -1,0 +1,116 @@
+package RT::Extension::REST2::Resource::UserGroups;
+use strict;
+use warnings;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'RT::Extension::REST2::Resource::Collection';
+with 'RT::Extension::REST2::Resource::Role::RequestBodyIsJSON' =>
+  {type => 'ARRAY'};
+
+has 'user' => (
+    is  => 'ro',
+    isa => 'RT::User',
+);
+
+sub dispatch_rules {
+    Path::Dispatcher::Rule::Regex->new(
+        regex => qr{^/user/([^/]+)/groups/?$},
+        block => sub {
+            my ($match, $req) = @_;
+            my $user_id = $match->pos(1);
+            my $user = RT::User->new($req->env->{"rt.current_user"});
+            $user->Load($user_id);
+
+            return {user => $user, collection => $user->OwnGroups(Recursively => $req->parameters->{recursively} // 1)};
+        },
+    ),
+    Path::Dispatcher::Rule::Regex->new(
+        regex => qr{^/user/([^/]+)/group/(\d+)/?$},
+        block => sub {
+            my ($match, $req) = @_;
+            my $user_id = $match->pos(1);
+            my $group_id = $match->pos(2) || '';
+            my $user = RT::User->new($req->env->{"rt.current_user"});
+            $user->Load($user_id);
+            my $collection = $user->OwnGroups(Recursively => 0);
+            $collection->Limit(FIELD => 'id', VALUE => $group_id);
+            return {user => $user, collection => $collection};
+        },
+    ),
+}
+
+sub forbidden {
+    my $self = shift;
+    return 0 if $self->current_user->HasRight(
+        Right   => "AdminUsers",
+        Object  => RT->System,
+    );
+    return 1;
+}
+
+sub serialize {
+    my $self = shift;
+    my $collection = $self->collection;
+    my @results;
+
+    while (my $item = $collection->Next) {
+        my $result = {
+            type => 'group',
+            id   => $item->id,
+            _url => RT::Extension::REST2->base_uri . "/group/" . $item->id,
+        };
+        push @results, $result;
+    }
+    return {
+        count       => scalar(@results)         + 0,
+        total       => $collection->CountAll    + 0,
+        per_page    => $collection->RowsPerPage + 0,
+        page        => ($collection->FirstRow / $collection->RowsPerPage) + 1,
+        items       => \@results,
+    };
+}
+
+sub allowed_methods {
+    my @ok = ('GET', 'HEAD', 'DELETE', 'PUT');
+    return \@ok;
+}
+
+sub content_types_accepted {[{'application/json' => 'from_json'}]}
+
+sub delete_resource {
+    my $self = shift;
+    my $collection = $self->collection;
+    while (my $group = $collection->Next) {
+        $RT::Logger->info('Delete user ' . $self->user->Name . ' from group '.$group->id);
+        $group->DeleteMember($self->user->id);
+    }
+    return 1;
+}
+
+sub from_json {
+    my $self   = shift;
+    my $params = JSON::decode_json($self->request->content);
+    my $user = $self->user;
+
+    my $method = $self->request->method;
+    my @results;
+    if ($method eq 'PUT') {
+        for my $param (@$params) {
+            if ($param =~ /^\d+$/) {
+                my $group = RT::Group->new($self->request->env->{"rt.current_user"});
+                $group->Load($param);
+                push @results, $group->AddMember($user->id);
+            } else {
+                push @results, [0, 'You should provide group id for each group user should be added'];
+            }
+        }
+    }
+    $self->response->body(JSON::encode_json(\@results));
+    return;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/t/group-members.t
+++ b/t/group-members.t
@@ -1,0 +1,261 @@
+use strict;
+use warnings;
+use lib 't/lib';
+use RT::Extension::REST2::Test tests => undef;
+use Test::Warn;
+
+my $mech = RT::Extension::REST2::Test->mech;
+
+my $auth = RT::Extension::REST2::Test->authorization_header;
+my $rest_base_path = '/REST/2.0';
+my $user = RT::Extension::REST2::Test->user;
+
+my $group1 = RT::Group->new(RT->SystemUser);
+my ($ok, $msg) = $group1->CreateUserDefinedGroup(Name => 'Group 1');
+ok($ok, $msg);
+
+my $user1 = RT::User->new(RT->SystemUser);
+($ok, $msg) = $user1->Create(Name => 'User 1');
+ok($ok, $msg);
+
+my $user2 = RT::User->new(RT->SystemUser);
+($ok, $msg) = $user2->Create(Name => 'User 2');
+ok($ok, $msg);
+
+# Group creation
+my ($group2_url, $group2_id);
+{
+    my $payload = {
+        Name => 'Group 2',
+    };
+
+    # Rights Test - No AdminGroup
+    my $res = $mech->post_json("$rest_base_path/group",
+        $payload,
+        'Authorization' => $auth,
+    );
+    is($res->code, 403, 'Cannot create group without AdminGroup right');
+
+    # Rights Test - With AdminGroup
+    $user->PrincipalObj->GrantRight(Right => 'AdminGroup');
+    $res = $mech->post_json("$rest_base_path/group",
+        $payload,
+        'Authorization' => $auth,
+    );
+    is($res->code, 201, 'Create group with AdminGroup right');
+    ok($group2_url = $res->header('location'), 'Created group url');
+    ok(($group2_id) = $group2_url =~ qr[/group/(\d+)], 'Created group id');
+}
+
+my $group2 = RT::Group->new(RT->SystemUser);
+$group2->Load($group2_id);
+
+# Group disabling
+{
+    # Rights Test - No AdminGroup
+    $user->PrincipalObj->RevokeRight(Right => 'AdminGroup');
+    my $res = $mech->delete($group2_url,
+        'Authorization' => $auth,
+    );
+    is($res->code, 403, 'Cannot disable group without AdminGroup right');
+
+    # Rights Test - With AdminGroup, no SeeGroup
+    $user->PrincipalObj->GrantRight(Right => 'AdminGroup', Object => $group2);
+    $res = $mech->delete($group2_url,
+        'Authorization' => $auth,
+    );
+    is($res->code, 403, 'Cannot disable group without SeeGroup right');
+
+    # Rights Test - With AdminGroup, no SeeGroup
+    $user->PrincipalObj->GrantRight(Right => 'SeeGroup', Object => $group2);
+    $res = $mech->delete($group2_url,
+        'Authorization' => $auth,
+    );
+    is($res->code, 204, 'Disable group with AdminGroup & SeeGroup rights');
+
+    is($group2->Disabled, 1, "Group disabled");
+}
+
+# Group enabling
+{
+    my $payload = {
+        Disabled => 0,
+    };
+
+    # Rights Test - No AdminGroup
+    $user->PrincipalObj->RevokeRight(Right => 'AdminGroup', Object => $group2);
+    $user->PrincipalObj->RevokeRight(Right => 'SeeGroup', Object => $group2);
+
+    my $res = $mech->put_json($group2_url,
+        $payload,
+        'Authorization' => $auth);
+    is($res->code, 403, 'Cannot enable group without AdminGroup right');
+
+    # Rights Test - With AdminGroup, no SeeGroup
+    $user->PrincipalObj->GrantRight(Right => 'AdminGroup', Object => $group2);
+    $res = $mech->put_json($group2_url,
+        $payload,
+        'Authorization' => $auth);
+    is($res->code, 403, 'Cannot enable group without SeeGroup right');
+
+    # Rights Test - With AdminGroup, no SeeGroup
+    $user->PrincipalObj->GrantRight(Right => 'SeeGroup', Object => $group2);
+    $res = $mech->put_json($group2_url,
+        $payload,
+        'Authorization' => $auth);
+    is($res->code, 200, 'Enable group with AdminGroup & SeeGroup rights');
+    is_deeply($mech->json_response, ['Group enabled']);
+
+    is($group2->Disabled, 0, "Group enabled");
+}
+
+my $group1_id = $group1->id;
+(my $group1_url = $group2_url) =~ s/$group2_id/$group1_id/;
+$user->PrincipalObj->GrantRight(Right => 'SeeGroup', Object => $group1);
+
+# Members addition
+{
+    my $payload = [
+        $user1->id,
+        $group2->id,
+        $user1->id + 666,
+    ];
+
+    # Rights Test - No AdminGroupMembership
+    my $res = $mech->put_json($group1_url . '/members',
+        $payload,
+        'Authorization' => $auth,
+    );
+    is($res->code, 403, 'Cannot add members to group without AdminGroupMembership right');
+
+    # Rights Test - With AdminGroupMembership
+    $user->PrincipalObj->GrantRight(Right => 'AdminGroupMembership', Object => $group1);
+    $res = $mech->put_json($group1_url . '/members',
+        $payload,
+        'Authorization' => $auth,
+    );
+    is($res->code, 200, 'Add members to group with AdminGroupMembership right');
+    is_deeply($mech->json_response, [
+            1, "Member added: " . $user1->Name,
+            1, "Member added: " . $group2->Name,
+            0, "Couldn't find that principal",
+    ], 'Two members added, bad principal rejected');
+    my $members1 = $group1->MembersObj;
+    is($members1->Count, 2, 'Two members added');
+    my $member = $members1->Next;
+    is($member->MemberObj->PrincipalType, 'User', 'User added as member');
+    is($member->MemberObj->id, $user1->id, 'Accurate user added as member');
+    $member = $members1->Next;
+    is($member->MemberObj->PrincipalType, 'Group', 'Group added as member');
+    is($member->MemberObj->id, $group2->id, 'Accurate group added as member');
+}
+
+# Members list
+{
+    # Add user to subgroup
+    $group2->AddMember($user2->id);
+
+    # Direct members
+    my $res = $mech->get($group1_url . '/members',
+        'Authorization' => $auth,
+    );
+    is($res->code, 200, 'List direct members');
+
+    my $content = $mech->json_response;
+    is($content->{total}, 2, 'Two direct members');
+    is($content->{items}->[0]->{type}, 'user', 'User member');
+    is($content->{items}->[0]->{id}, $user1->id, 'Accurate user member');
+    is($content->{items}->[1]->{type}, 'group', 'Group member');
+    is($content->{items}->[1]->{id}, $group2->id, 'Accurate group member');
+
+    # Deep members
+    $res = $mech->get($group1_url . '/deepmembers',
+        'Authorization' => $auth,
+    );
+    is($res->code, 200, 'List deep members');
+
+    $content = $mech->json_response;
+    is($content->{total}, 4, 'Four deep members');
+    is($content->{items}->[0]->{type}, 'group', 'First group deep member');
+    is($content->{items}->[0]->{id}, $group1->id, 'First accurate group deep member');
+    is($content->{items}->[1]->{type}, 'user', 'First user deep member');
+    is($content->{items}->[1]->{id}, $user1->id, 'First accurate user deep member');
+    is($content->{items}->[2]->{type}, 'user', 'Second user member');
+    is($content->{items}->[2]->{id}, $user2->id, 'Second accurate user deep member');
+    is($content->{items}->[3]->{type}, 'group', 'Second group deep member');
+    is($content->{items}->[3]->{id}, $group2->id, 'Second accurate group deep member');
+
+    # Direct user members
+    $res = $mech->get($group1_url . '/usermembers?recursively=0',
+        'Authorization' => $auth,
+    );
+    is($res->code, 200, 'List direct user members');
+
+    $content = $mech->json_response;
+    is($content->{total}, 1, 'One direct user member');
+    is($content->{items}->[0]->{type}, 'user', 'Direct user member');
+    is($content->{items}->[0]->{id}, $user1->id, 'Accurate direct user member');
+
+    # Recursive user members
+    $res = $mech->get($group1_url . '/usermembers',
+        'Authorization' => $auth,
+    );
+    is($res->code, 200, 'List recursive user members');
+
+    $content = $mech->json_response;
+    is($content->{total}, 2, 'Two recursive user members');
+    is($content->{items}->[0]->{type}, 'user', 'First recursive user member');
+    is($content->{items}->[0]->{id}, $user1->id, 'First accurate recursive user member');
+    is($content->{items}->[1]->{type}, 'user', 'Second recursive user member');
+    is($content->{items}->[1]->{id}, $user2->id, 'Second accurate recursive user member');
+
+    # Direct group members
+    $res = $mech->get($group1_url . '/groupmembers?recursively=0',
+        'Authorization' => $auth,
+    );
+    is($res->code, 200, 'List direct group members');
+
+    $content = $mech->json_response;
+    is($content->{total}, 1, 'One direct group member');
+    is($content->{items}->[0]->{type}, 'group', 'Direct group member');
+    is($content->{items}->[0]->{id}, $group2->id, 'Accurate direct group member');
+
+    # Recursive group members
+    $res = $mech->get($group1_url . '/groupmembers',
+        'Authorization' => $auth,
+    );
+    is($res->code, 200, 'List recursive group members');
+
+    $content = $mech->json_response;
+    is($content->{total}, 2, 'Two recursive group members');
+    is($content->{items}->[0]->{type}, 'group', 'First recursive group member');
+    is($content->{items}->[0]->{id}, $group1->id, 'First accurate recursive group member');
+    is($content->{items}->[1]->{type}, 'group', 'Second recursive group member');
+    is($content->{items}->[1]->{id}, $group2->id, 'Second accurate recursive group member');
+}
+
+# Members removal
+{
+    my $res = $mech->delete($group1_url . '/member/' . $user1->id,
+        'Authorization' => $auth,
+    );
+    is($res->code, 204, 'Remove member');
+    my $members1 = $group1->MembersObj;
+    is($members1->Count, 1, 'One member removed');
+    my $member = $members1->Next;
+    is($member->MemberObj->PrincipalType, 'Group', 'Group remaining member');
+    is($member->MemberObj->id, $group2->id, 'Accurate remaining member');
+}
+
+# All members removal
+{
+    my $res = $mech->delete($group1_url . '/members',
+        'Authorization' => $auth,
+    );
+    is($res->code, 204, 'Remove all members');
+    my $members1 = $group1->MembersObj;
+    is($members1->Count, 0, 'All members removed');
+}
+
+done_testing;
+

--- a/t/group-members.t
+++ b/t/group-members.t
@@ -257,5 +257,21 @@ $user->PrincipalObj->GrantRight(Right => 'SeeGroup', Object => $group1);
     is($members1->Count, 0, 'All members removed');
 }
 
+# Group hypermedia links
+{
+    my $res = $mech->get("$rest_base_path/group/$group1_id",
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+    my $content = $mech->json_response;
+    my $links = $content->{_hyperlinks};
+    my @members_links = grep { $_->{ref} =~ /members/ } @$links;
+    is(scalar(@members_links), 4);
+    like($members_links[0]->{_url}, qr{$rest_base_path/group/$group1_id/members$});
+    like($members_links[1]->{_url}, qr{$rest_base_path/group/$group1_id/deepmembers$});
+    like($members_links[2]->{_url}, qr{$rest_base_path/group/$group1_id/groupmembers$});
+    like($members_links[3]->{_url}, qr{$rest_base_path/group/$group1_id/usermembers$});
+}
+
 done_testing;
 

--- a/t/ticket-customroles.t
+++ b/t/ticket-customroles.t
@@ -41,7 +41,7 @@ for my $email (qw/multi@example.com test@localhost multi2@example.com single2@ex
 }
 
 $user->PrincipalObj->GrantRight( Right => $_ )
-    for qw/CreateTicket ShowTicket ModifyTicket OwnTicket AdminUsers/;
+    for qw/CreateTicket ShowTicket ModifyTicket OwnTicket AdminUsers SeeGroup/;
 
 # Create and view ticket with no watchers
 {

--- a/t/ticket-watchers.t
+++ b/t/ticket-watchers.t
@@ -13,7 +13,7 @@ my $user = RT::Extension::REST2::Test->user;
 my $queue = RT::Test->load_or_create_queue( Name => "General" );
 
 $user->PrincipalObj->GrantRight( Right => $_ )
-    for qw/CreateTicket ShowTicket ModifyTicket OwnTicket AdminUsers/;
+    for qw/CreateTicket ShowTicket ModifyTicket OwnTicket AdminUsers SeeGroup/;
 
 # Create and view ticket with no watchers
 {

--- a/t/user-memberships.t
+++ b/t/user-memberships.t
@@ -1,0 +1,105 @@
+use strict;
+use warnings;
+use lib 't/lib';
+use RT::Extension::REST2::Test tests => undef;
+use Test::Warn;
+
+my $mech = RT::Extension::REST2::Test->mech;
+
+my $auth = RT::Extension::REST2::Test->authorization_header;
+my $rest_base_path = '/REST/2.0';
+my $user = RT::Extension::REST2::Test->user;
+
+my $group1 = RT::Group->new(RT->SystemUser);
+my ($ok, $msg) = $group1->CreateUserDefinedGroup(Name => 'Group 1');
+ok($ok, $msg);
+
+my $group2 = RT::Group->new(RT->SystemUser);
+($ok, $msg) = $group2->CreateUserDefinedGroup(Name => 'Group 2');
+ok($ok, $msg);
+
+($ok, $msg) = $group1->AddMember($group2->id);
+ok($ok, $msg);
+
+# Membership addition
+{
+    my $payload = [ $group2->id ];
+
+    # Rights Test - No ModifyOwnMembership
+    my $res = $mech->put_json("$rest_base_path/user/" . $user->id . '/groups',
+        $payload,
+        'Authorization' => $auth,
+    );
+    is($res->code, 403, 'Cannot add user to group without ModifyOwnMembership right');
+    
+    # Rights Test - With ModifyOwnMembership
+    $user->PrincipalObj->GrantRight(Right => 'ModifyOwnMembership');
+    $res = $mech->put_json("$rest_base_path/user/" . $user->id . '/groups',
+        $payload,
+        'Authorization' => $auth,
+    );
+    is($res->code, 200, 'Add user to group with ModifyOwnMembership right');
+    my $members2 = $group2->MembersObj;
+    is($members2->Count, 1, 'One member added');
+    my $member = $members2->Next;
+    is($member->MemberObj->PrincipalType, 'User', 'User added as member');
+    is($member->MemberObj->id, $user->id, 'Accurate user added as member');
+}
+
+
+# Memberships list
+{
+    # Rights Test - No SeeGroup
+    my $res = $mech->get("$rest_base_path/user/" . $user->id . '/groups',
+        'Authorization' => $auth,
+    );
+    is($res->code, 200, 'List direct members');
+
+    my $content = $mech->json_response;
+    is($content->{total}, 2, 'Two recursive memberships');
+    is(scalar(@{$content->{items}}), 0, 'Cannot see memberships content withtout SeeGroup right');
+    
+    # Recursive memberships
+    $user->PrincipalObj->GrantRight(Right => 'SeeGroup');
+    $res = $mech->get("$rest_base_path/user/" . $user->id . '/groups',
+        'Authorization' => $auth,
+    );
+    is($res->code, 200, 'List direct members');
+
+    $content = $mech->json_response;
+    is($content->{total}, 2, 'Two recursive memberships');
+    is($content->{items}->[0]->{type}, 'group', 'First group membership');
+    is($content->{items}->[0]->{id}, $group1->id, 'Accurate first group membership');
+    is($content->{items}->[1]->{type}, 'group', 'Second group membership');
+    is($content->{items}->[1]->{id}, $group2->id, 'Accurate second group membership');
+}
+
+($ok, $msg) = $group1->AddMember($user->id);
+ok($ok, $msg);
+
+# Membership removal
+{
+    my $res = $mech->delete("$rest_base_path/user/" . $user->id . '/group/' . $group2->id,
+        'Authorization' => $auth,
+    );
+    is($res->code, 204, 'Remove membership');
+    my $memberships = $user->OwnGroups;
+    is($memberships->Count, 1, 'One membership removed');
+    my $membership = $memberships->Next;
+    is($membership->id, $group1->id, 'Accurate membership removed');
+}
+
+($ok, $msg) = $group2->AddMember($user->id);
+ok($ok, $msg);
+
+# All members removal
+{
+    my $res = $mech->delete("$rest_base_path/user/" . $user->id . '/groups',
+        'Authorization' => $auth,
+    );
+    is($res->code, 204, 'Remove all memberships');
+    my $memberships = $user->OwnGroups;
+    is($memberships->Count, 0, 'All membership removed');
+}
+
+done_testing;

--- a/t/user-memberships.t
+++ b/t/user-memberships.t
@@ -102,4 +102,18 @@ ok($ok, $msg);
     is($memberships->Count, 0, 'All membership removed');
 }
 
+# User hypermedia links
+{
+    my $res = $mech->get("$rest_base_path/user/" . $user->id,
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+    my $content = $mech->json_response;
+    my $links = $content->{_hyperlinks};
+    my @memberships_links = grep { $_->{ref} eq 'memberships' } @$links;
+    is(scalar(@memberships_links), 1);
+    my $user_id = $user->id;
+    like($memberships_links[0]->{_url}, qr{$rest_base_path/user/$user_id/groups$});
+}
+
 done_testing;


### PR DESCRIPTION
Extends REST2 API with some endpoints on group members and user memberships (also create/disable a group + enable/disable a group or a user and retrieve user memberships). Find below additions to README:

   Users

        GET /user/:id
        GET /user/:name
             retrieve a user by numeric id or username (including its memberships and whether it is disabled)

        PUT /user/:id
        PUT /user/:name
             update a user's metadata (including its Disabled status); provide JSON content

   Groups

        POST /group
             create a (user defined) group; provide JSON content

        GET /group/:id
            retrieve a group (including its members and whether it is disabled)

        PUT /group/:id
            update a groups's metadata (including its Disabled status); provide JSON content

        DELETE /group/:id
            disable group

   User Memberships

        GET /user/:id/groups
        GET /user/:name/groups
            retrieve list of groups which a user is a member of

        PUT /user/:id/groups
        PUT /user/:name/groups
            add a user to groups; provide a JSON array of groups ids

        DELETE /user/:id/group/:id
        DELETE /user/:name/group/:id
            remove a user from a group

        DELETE /user/:id/groups
        DELETE /user/:name/groups
            remove a user from all groups

   Group Members

        GET /group/:id/members
            retrieve list of direct members of a group
            retrieve list of direct members of a group

        GET /group/:id/deepmembers
            retrieve list of direct and recursive members of a group

        GET /group/:id/groupmembers
        GET /group/:id/groupmembers?recursively=0
            retrieve list of group members of a group, by default recursively
            or only direct group members passing parameter recursively=0

        GET /group/:id/usermembers
        GET /group/:id/usermembers?recursively=0
            retrieve list of user members of a group, by default recursively
            or only direct user members passing parameter recursively=0

        PUT /group/:id/members
            add members to a group; provide a JSON array of principal ids

        DELETE /group/:id/member/:id
            remove a member from a group

        DELETE /group/:id/members
            remove all members from a group
            remove a member from a group

        DELETE /group/:id/members
            remove all members from a group