### PR TITLE
Searches disabled

### DIFF
--- a/README
+++ b/README
@@ -462,6 +462,10 @@ USAGE
             ]
         '
 
+    By default, only enabled objects are returned. For results to include
+    also disabled objectn you should specify find_disabled_rows=1 as query
+    parameter.
+
     The JSON payload must be an array of hashes with the keys field and
     value and optionally operator.
 

--- a/lib/RT/Extension/REST2.pm
+++ b/lib/RT/Extension/REST2.pm
@@ -509,6 +509,8 @@ values).  An example:
         ]
     '
 
+By default, only enabled objects are returned. For results to include also disabled objectn you should specify C<find_disabled_rows=1> as query parameter.
+
 The JSON payload must be an array of hashes with the keys C<field> and C<value>
 and optionally C<operator>.
 

--- a/lib/RT/Extension/REST2/Resource/Collection/QueryByJSON.pm
+++ b/lib/RT/Extension/REST2/Resource/Collection/QueryByJSON.pm
@@ -45,6 +45,9 @@ sub limit_collection {
     my @fields      = $self->searchable_fields;
     my %searchable  = map {; $_ => 1 } @fields;
 
+    $collection->{'find_disabled_rows'} = 1
+        if $self->request->param('find_disabled_rows');
+
     for my $limit (@$query) {
         next unless $limit->{field}
                 and $searchable{$limit->{field}}

--- a/t/search-json.t
+++ b/t/search-json.t
@@ -138,5 +138,58 @@ my $bravo_id = $bravo->Id;
     is($content->{message}, 'JSON object must be a ARRAY');
 }
 
+# Find disabled row
+{
+    $alpha->SetDisabled(1);
+
+    my $res = $mech->post_json("$rest_base_path/queues",
+        [{ field => 'id', operator => '>', value => 2 }],
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+
+    my $content = $mech->json_response;
+    is($content->{count}, 2);
+    is($content->{page}, 1);
+    is($content->{per_page}, 20);
+    is($content->{total}, 2);
+    is(scalar @{$content->{items}}, 2);
+
+    my ($first, $second) = @{ $content->{items} };
+    is($first->{type}, 'queue');
+    is($first->{id}, $beta_id);
+    like($first->{_url}, qr{$rest_base_path/queue/$beta_id$});
+
+    is($second->{type}, 'queue');
+    is($second->{id}, $bravo_id);
+    like($second->{_url}, qr{$rest_base_path/queue/$bravo_id$});
+
+    my $res_disabled = $mech->post_json("$rest_base_path/queues?find_disabled_rows=1",
+        [{ field => 'id', operator => '>', value => 2 }],
+        'Authorization' => $auth,
+    );
+    is($res_disabled->code, 200);
+
+    my $content_disabled = $mech->json_response;
+    is($content_disabled->{count}, 3);
+    is($content_disabled->{page}, 1);
+    is($content_disabled->{per_page}, 20);
+    is($content_disabled->{total}, 3);
+    is(scalar @{$content_disabled->{items}}, 3);
+
+    my ($first_disabled, $second_disabled, $third_disabled) = @{ $content_disabled->{items} };
+    is($first_disabled->{type}, 'queue');
+    is($first_disabled->{id}, $alpha_id);
+    like($first_disabled->{_url}, qr{$rest_base_path/queue/$alpha_id$});
+
+    is($second_disabled->{type}, 'queue');
+    is($second_disabled->{id}, $beta_id);
+    like($second_disabled->{_url}, qr{$rest_base_path/queue/$beta_id$});
+
+    is($third_disabled->{type}, 'queue');
+    is($third_disabled->{id}, $bravo_id);
+    like($third_disabled->{_url}, qr{$rest_base_path/queue/$bravo_id$});
+}
+
 done_testing;
 


### PR DESCRIPTION
This pull request allows to return disabled objects in JSON searches. Here's the doc:

  JSON searches
    Some resources accept a basic JSON structure as the search conditions
    which specifies one or more fields to limit on (using specified
    operators and values). An example:

        curl -si -u user:pass https://rt.example.com/REST/2.0/queues -XPOST --data-binary '
            [
                { "field":    "Name",
                  "operator": "LIKE",
                  "value":    "Engineering" },

                { "field":    "Lifecycle",
                  "value":    "helpdesk" }
            ]
        '

    By default, only enabled objects are returned. For results to include
    also disabled objectn you should specify find_disabled_rows=1 as query
    parameter.

    The JSON payload must be an array of hashes with the keys field and
    value and optionally operator.

    Results are returned in the format described below.