### PR TITLE
Searches entry aggregator

### DIFF
--- a/README
+++ b/README
@@ -465,6 +465,36 @@ USAGE
     The JSON payload must be an array of hashes with the keys field and
     value and optionally operator.
 
+    The same field is specified more than one time to express more than one
+    condition on this field. For example:
+
+        [
+            { "field":    "id",
+              "operator": ">",
+              "value":    $min },
+
+            { "field":     "id",
+              "operator": "<",
+              "value":    $max }
+        ]
+
+    By default, RT will aggregate these conditions with a OR, safe for
+    searching queues, where a AND is applied. If you want to search for
+    multiple conditions on the same field aggregated with a AND (or a OR for
+    queues), you have to specify entry_aggregator keys in corresponding
+    hashes:
+
+        [
+            { "field":    "id",
+              "operator": ">",
+              "value":    $min },
+
+            { "field":             "id",
+              "operator":         "<",
+              "value":            $max,
+              "entry_aggregator": "AND" }
+        ]
+
     Results are returned in the format described below.
 
   Example of plural resources (collections)

--- a/lib/RT/Extension/REST2.pm
+++ b/lib/RT/Extension/REST2.pm
@@ -512,6 +512,31 @@ values).  An example:
 The JSON payload must be an array of hashes with the keys C<field> and C<value>
 and optionally C<operator>.
 
+The same C<field> is specified more than one time to express more than one condition on this field. For example:
+
+    [
+        { "field":    "id",
+          "operator": ">",
+          "value":    $min },
+
+        { "field":     "id",
+          "operator": "<",
+          "value":    $max }
+    ]
+
+By default, RT will aggregate these conditions with a C<OR>, safe for searching queues, where a C<AND> is applied. If you want to search for multiple conditions on the same field aggregated with a C<AND> (or a C<OR> for queues), you have to specify C<entry_aggregator> keys in corresponding hashes:
+
+    [
+        { "field":    "id",
+          "operator": ">",
+          "value":    $min },
+
+        { "field":             "id",
+          "operator":         "<",
+          "value":            $max,
+          "entry_aggregator": "AND" }
+    ]
+
 Results are returned in
 L<the format described below|/"Example of plural resources (collections)">.
 

--- a/lib/RT/Extension/REST2/Resource/Collection/QueryByJSON.pm
+++ b/lib/RT/Extension/REST2/Resource/Collection/QueryByJSON.pm
@@ -57,6 +57,9 @@ sub limit_collection {
                 ? (OPERATOR => $limit->{operator})
                 : () ),
             CASESENSITIVE => ($limit->{case_sensitive} || 0),
+            ( $limit->{entry_aggregator}
+                ? (ENTRYAGGREGATOR => $limit->{entry_aggregator})
+                : () ),
         );
     }
     return 1;

--- a/t/search-json.t
+++ b/t/search-json.t
@@ -138,5 +138,86 @@ my $bravo_id = $bravo->Id;
     is($content->{message}, 'JSON object must be a ARRAY');
 }
 
+# Aggregate conditions with OR, Queues defaults to AND
+{
+    my $res = $mech->post_json("$rest_base_path/queues",
+        [
+            { field => 'id', operator => '>', value => 2 },
+            { entry_aggregator => 'OR', field => 'id', operator => '<', value => 4 },
+        ],
+        'Authorization' => $auth,
+    );
+
+    my $content = $mech->json_response;
+    is($content->{count}, 4);
+    is($content->{page}, 1);
+    is($content->{per_page}, 20);
+    is($content->{total}, 4);
+    is(scalar @{$content->{items}}, 4);
+    my @ids = sort map {$_->{id}} @{$content->{items}};
+    is_deeply(\@ids, [1, $alpha_id, $beta_id, $bravo_id]);
+}
+
+# Aggregate conditions with AND, Queues defaults to AND
+{
+    my $res = $mech->post_json("$rest_base_path/queues",
+        [
+            { field => 'id', operator => '>', value => 2 },
+            { field => 'id', operator => '<', value => 4 },
+        ],
+        'Authorization' => $auth,
+    );
+
+    my $content = $mech->json_response;
+    is($content->{count}, 1);
+    is($content->{page}, 1);
+    is($content->{per_page}, 20);
+    is($content->{total}, 1);
+    is(scalar @{$content->{items}}, 1);
+    is($content->{items}->[0]->{id}, $alpha_id);
+}
+
+my $cf1 = RT::Test->load_or_create_custom_field(Name  => 'cf1', Type  => 'FreeformSingle', Queue => 'General');
+my $cf2 = RT::Test->load_or_create_custom_field(Name  => 'cf2', Type  => 'FreeformSingle', Queue => 'General');
+my $cf3 = RT::Test->load_or_create_custom_field(Name  => 'cf3', Type  => 'FreeformSingle', Queue => 'General');
+# Aggregate conditions with OR, CustomFields defaults to OR
+{
+    my $res = $mech->post_json("$rest_base_path/customfields",
+        [
+            { field => 'id', operator => '>', value => 2 },
+            { field => 'id', operator => '<', value => 4 },
+        ],
+        'Authorization' => $auth,
+    );
+
+    my $content = $mech->json_response;
+    is($content->{count}, 4);
+    is($content->{page}, 1);
+    is($content->{per_page}, 20);
+    is($content->{total}, 4);
+    is(scalar @{$content->{items}}, 4);
+    my @ids = sort map {$_->{id}} @{$content->{items}};
+    is_deeply(\@ids, [1, 2, 3, 4]);
+}
+
+# Aggregate conditions with AND, CustomFields defaults to OR
+{
+    my $res = $mech->post_json("$rest_base_path/customfields",
+        [
+            { field => 'id', operator => '>', value => 2 },
+            { entry_aggregator => 'AND', field => 'id', operator => '<', value => 4 },
+        ],
+        'Authorization' => $auth,
+    );
+
+    my $content = $mech->json_response;
+    is($content->{count}, 1);
+    is($content->{page}, 1);
+    is($content->{per_page}, 20);
+    is($content->{total}, 1);
+    is(scalar @{$content->{items}}, 1);
+    is($content->{items}->[0]->{id}, 3);
+}
+
 done_testing;
 


### PR DESCRIPTION
This pull request allows to specify an entry aggregator for filters of JSON searches. Here's the doc:

The same field is specified more than one time to express more than one
    condition on this field. For example:

        [
            { "field":    "id",
              "operator": ">",
              "value":    $min },

            { "field":     "id",
              "operator": "<",
              "value":    $max }
        ]

    By default, RT will aggregate these conditions with a OR, safe for
    searching queues, where a AND is applied. If you want to search for
    multiple conditions on the same field aggregated with a AND (or a OR for
    queues), you have to specify entry_aggregator keys in corresponding
    hashes:

        [
            { "field":    "id",
              "operator": ">",
              "value":    $min },

            { "field":             "id",
              "operator":         "<",
              "value":            $max,
              "entry_aggregator": "AND" }
        ]

    Results are returned in the format described below.