### PR TITLE
Orderby searches

### DIFF
--- a/README
+++ b/README
@@ -465,6 +465,25 @@ USAGE
     The JSON payload must be an array of hashes with the keys field and
     value and optionally operator.
 
+    Results can be sorted by using multiple query parameter arguments
+    orderby and order. Each orderby query parameter specify a field to be
+    used for sorting results. If the request includes more than one orderby
+    query parameter, results are sorted according to corresponding fields in
+    the same order than they are specified. For instance, if you want to
+    sort results according to creation date and then by id (in case of some
+    items have the same creation date), your request should specify
+    ?orderby=Created&orderby=id. By default, results are sorted in ascending
+    order. To sort results in descending order, you should use order=DESC
+    query parameter. Any other value for order query parameter will be
+    treated as order=ASC, for ascending order. The order of the order query
+    parameters should be the same as the orderby query parameters.
+    Therefore, if you specify two fields to sort the results (with two
+    orderby parameters) and you want to sort the second field by descending
+    order, you should also explicitely specify order=ASC for the first
+    field: orderby=Created&order=ASC&orderby=id&order=DESC. orderby and
+    order query parameters are used the smae way for JSON searches and for
+    TicketSQL searches.
+
     Results are returned in the format described below.
 
   Example of plural resources (collections)

--- a/lib/RT/Extension/REST2.pm
+++ b/lib/RT/Extension/REST2.pm
@@ -512,6 +512,8 @@ values).  An example:
 The JSON payload must be an array of hashes with the keys C<field> and C<value>
 and optionally C<operator>.
 
+Results can be sorted by using multiple query parameter arguments C<orderby> and C<order>. Each C<orderby> query parameter specify a field to be used for sorting results. If the request includes more than one C<orderby> query parameter, results are sorted according to corresponding fields in the same order than they are specified. For instance, if you want to sort results according to creation date and then by id (in case of some items have the same creation date), your request should specify C<?orderby=Created&orderby=id>. By default, results are sorted in ascending order. To sort results in descending order, you should use C<order=DESC> query parameter. Any other value for C<order> query parameter will be treated as C<order=ASC>, for ascending order. The order of the C<order> query parameters should be the same as the C<orderby> query parameters. Therefore, if you specify two fields to sort the results (with two C<orderby> parameters) and you want to sort the second field by descending order, you should also explicitely specify C<order=ASC> for the first field: C<orderby=Created&order=ASC&orderby=id&order=DESC>. C<orderby> and C<order> query parameters are used the smae way for JSON searches and for TicketSQL searches.
+
 Results are returned in
 L<the format described below|/"Example of plural resources (collections)">.
 

--- a/lib/RT/Extension/REST2/Resource/Collection/QueryByJSON.pm
+++ b/lib/RT/Extension/REST2/Resource/Collection/QueryByJSON.pm
@@ -59,6 +59,18 @@ sub limit_collection {
             CASESENSITIVE => ($limit->{case_sensitive} || 0),
         );
     }
+
+    my @orderby_cols;
+    my @orders = $self->request->param('order');
+    foreach my $orderby ($self->request->param('orderby')) {
+        my $order = shift @orders || 'ASC';
+        $order = uc($order);
+        $order = 'ASC' unless $order eq 'DESC';
+        push @orderby_cols, {FIELD => $orderby, ORDER => $order};
+    }
+    $self->collection->OrderByCols(@orderby_cols)
+        if @orderby_cols;
+
     return 1;
 }
 

--- a/lib/RT/Extension/REST2/Resource/Tickets.pm
+++ b/lib/RT/Extension/REST2/Resource/Tickets.pm
@@ -50,6 +50,19 @@ sub limit_collection {
     my $self = shift;
     my ($ok, $msg) = $self->collection->FromSQL( $self->query );
     return error_as_json( $self->response, 0, $msg ) unless $ok;
+
+    my @orderby_cols;
+    my @orders = $self->request->param('order');
+    foreach my $orderby ($self->request->param('orderby')) {
+        $orderby = decode_utf8($orderby);
+        my $order = shift @orders || 'ASC';
+        $order = uc(decode_utf8($order));
+        $order = 'ASC' unless $order eq 'DESC';
+        push @orderby_cols, {FIELD => $orderby, ORDER => $order};
+    }
+    $self->collection->OrderByCols(@orderby_cols)
+        if @orderby_cols;
+
     return 1;
 }
 

--- a/t/search-json.t
+++ b/t/search-json.t
@@ -8,9 +8,9 @@ my $auth = RT::Extension::REST2::Test->authorization_header;
 my $rest_base_path = '/REST/2.0';
 my $user = RT::Extension::REST2::Test->user;
 
-my $alpha = RT::Test->load_or_create_queue( Name => 'Alpha' );
-my $beta  = RT::Test->load_or_create_queue( Name => 'Beta' );
-my $bravo = RT::Test->load_or_create_queue( Name => 'Bravo' );
+my $alpha = RT::Test->load_or_create_queue( Name => 'Alpha', Description => 'Queue for test' );
+my $beta  = RT::Test->load_or_create_queue( Name => 'Beta', Description => 'Queue for test' );
+my $bravo = RT::Test->load_or_create_queue( Name => 'Bravo', Description => 'Queue to test sorted search' );
 $user->PrincipalObj->GrantRight( Right => 'SuperUser' );
 
 my $alpha_id = $alpha->Id;
@@ -136,6 +136,35 @@ my $bravo_id = $bravo->Id;
         is($content->{message}, 'Query must be an array of objects');
     }
     is($content->{message}, 'JSON object must be a ARRAY');
+}
+
+# Sorted search
+{
+    my $res = $mech->post_json("$rest_base_path/queues?orderby=Description&order=DESC&orderby=id",
+        [{ field => 'Description', operator => 'LIKE', value => 'test' }],
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+
+    my $content = $mech->json_response;
+    is($content->{count}, 3);
+    is($content->{page}, 1);
+    is($content->{per_page}, 20);
+    is($content->{total}, 3);
+    is(scalar @{$content->{items}}, 3);
+
+    my ($first, $second, $third) = @{ $content->{items} };
+    is($first->{type}, 'queue');
+    is($first->{id}, $bravo_id);
+    like($first->{_url}, qr{$rest_base_path/queue/$bravo_id$});
+
+    is($second->{type}, 'queue');
+    is($second->{id}, $alpha_id);
+    like($second->{_url}, qr{$rest_base_path/queue/$alpha_id$});
+
+    is($third->{type}, 'queue');
+    is($third->{id}, $beta_id);
+    like($third->{_url}, qr{$rest_base_path/queue/$beta_id$});
 }
 
 done_testing;


### PR DESCRIPTION
This pull request allows to sort results both in JSON searches and TicketSQL requests. Here's the doc:

    Results can be sorted by using multiple query parameter arguments
    orderby and order. Each orderby query parameter specify a field to be
    used for sorting results. If the request includes more than one orderby
    query parameter, results are sorted according to corresponding fields in
    the same order than they are specified. For instance, if you want to
    sort results according to creation date and then by id (in case of some
    items have the same creation date), your request should specify
    ?orderby=Created&orderby=id. By default, results are sorted in ascending
    order. To sort results in descending order, you should use order=DESC
    query parameter. Any other value for order query parameter will be
    treated as order=ASC, for ascending order. The order of the order query
    parameters should be the same as the orderby query parameters.
    Therefore, if you specify two fields to sort the results (with two
    orderby parameters) and you want to sort the second field by descending
    order, you should also explicitely specify order=ASC for the first
    field: orderby=Created&order=ASC&orderby=id&order=DESC. orderby and
    order query parameters are used the smae way for JSON searches and for
    TicketSQL searches.