### PR TITLE
Customfields by object applied to

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -66,6 +66,7 @@ t/asset-customfields.t
 t/assets.t
 t/catalogs.t
 t/conflict.t
+t/customfields.t
 t/lib/RT/Extension/REST2/Test.pm.in
 t/not_found.t
 t/organization.t

--- a/README
+++ b/README
@@ -428,6 +428,18 @@ USAGE
         POST /customfields
             search for custom fields using L</JSON searches> syntax
 
+        GET /catalog/:id/customfields?query=<JSON>
+        POST /catalog/:id/customfields
+            search for custom fields attached to a catalog using L</JSON searches> syntax
+
+        GET /class/:id/customfields?query=<JSON>
+        POST /class/:id/customfields
+            search for custom fields attached to a class using L</JSON searches> syntax
+
+        GET /queue/:id/customfields?query=<JSON>
+        POST /queue/:id/customfields
+            search for custom fields attached to a queue using L</JSON searches> syntax
+
         GET /customfield/:id
             retrieve a custom field
 

--- a/lib/RT/Extension/REST2.pm
+++ b/lib/RT/Extension/REST2.pm
@@ -472,6 +472,18 @@ Below are some examples using the endpoints above.
     POST /customfields
         search for custom fields using L</JSON searches> syntax
 
+    GET /catalog/:id/customfields?query=<JSON>
+    POST /catalog/:id/customfields
+        search for custom fields attached to a catalog using L</JSON searches> syntax
+
+    GET /class/:id/customfields?query=<JSON>
+    POST /class/:id/customfields
+        search for custom fields attached to a class using L</JSON searches> syntax
+
+    GET /queue/:id/customfields?query=<JSON>
+    POST /queue/:id/customfields
+        search for custom fields attached to a queue using L</JSON searches> syntax
+
     GET /customfield/:id
         retrieve a custom field
 

--- a/lib/RT/Extension/REST2/Resource/CustomFields.pm
+++ b/lib/RT/Extension/REST2/Resource/CustomFields.pm
@@ -8,12 +8,39 @@ use namespace::autoclean;
 extends 'RT::Extension::REST2::Resource::Collection';
 with 'RT::Extension::REST2::Resource::Collection::QueryByJSON';
 
+has 'object_applied_to' => (
+    is  => 'ro',
+    required => 0,
+);
+
 sub dispatch_rules {
     Path::Dispatcher::Rule::Regex->new(
         regex => qr{^/customfields/?$},
         block => sub { { collection_class => 'RT::CustomFields' } },
     ),
+    Path::Dispatcher::Rule::Regex->new(
+        regex => qr{^/(catalog|class|queue)/(\d+)/customfields/?$},
+        block => sub {
+            my ($match, $req) = @_;
+            my $object_type = 'RT::'. ucfirst($match->pos(1));
+            my $object_id = $match->pos(2);
+            my $object_applied_to = $object_type->new($req->env->{"rt.current_user"});
+            $object_applied_to->Load($object_id);
+            return {object_applied_to => $object_applied_to, collection_class => 'RT::CustomFields'};
+        },
+    ),
 }
+
+after 'limit_collection' => sub {
+    my $self = shift;
+    my $collection = $self->collection;
+    my $object = $self->object_applied_to;
+    if ($object && $object->id) {
+        $collection->Limit(ENTRYAGGREGATOR => "AND", FIELD => 'LookupType', OPERATOR => 'STARTSWITH', VALUE => ref($object));
+        $collection->LimitToGlobalOrObjectId($object->id);
+    }
+    return 1;
+};
 
 __PACKAGE__->meta->make_immutable;
 

--- a/t/customfields.t
+++ b/t/customfields.t
@@ -1,0 +1,221 @@
+use strict;
+use warnings;
+use lib 't/lib';
+use RT::Extension::REST2::Test tests => undef;
+
+my $mech = RT::Extension::REST2::Test->mech;
+my $auth = RT::Extension::REST2::Test->authorization_header;
+my $rest_base_path = '/REST/2.0';
+my $user = RT::Extension::REST2::Test->user;
+
+my $freeform_cf = RT::CustomField->new(RT->SystemUser);
+$freeform_cf->Create(Name => 'Freeform CF', Type => 'Freeform', MaxValues => 1, Queue => 'General');
+my $freeform_cf_id = $freeform_cf->id;
+
+my $select_cf = RT::CustomField->new(RT->SystemUser);
+$select_cf->Create(Name => 'Select CF', Type => 'Select', MaxValues => 1, Queue => 'General');
+$select_cf->AddValue(Name => 'First Value', SortOder => 0);
+$select_cf->AddValue(Name => 'Second Value', SortOrder => 1);
+$select_cf->AddValue(Name => 'Third Value', SortOrder => 2);
+my $select_cf_id = $select_cf->id;
+my $select_cf_values = $select_cf->Values->ItemsArrayRef;
+
+my $basedon_cf = RT::CustomField->new(RT->SystemUser);
+$basedon_cf->Create(Name => 'SubSelect CF', Type => 'Select', MaxValues => 1, Queue => 'General', BasedOn => $select_cf->id);
+$basedon_cf->AddValue(Name => 'With First Value', Category => $select_cf_values->[0]->Name, SortOder => 0);
+$basedon_cf->AddValue(Name => 'With No Value', SortOder => 0);
+my $basedon_cf_id = $basedon_cf->id;
+my $basedon_cf_values = $basedon_cf->Values->ItemsArrayRef;
+
+# Right test - search all tickets customfields without SeeCustomField
+{
+    my $res = $mech->post_json("$rest_base_path/customfields",
+        [{field => 'LookupType', value => 'RT::Queue-RT::Ticket'}],
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+
+    my $content = $mech->json_response;
+    is($content->{total}, 3);
+    is($content->{count}, 0);
+    is_deeply($content->{items}, []);
+}
+
+# search all tickets customfields
+{
+    $user->PrincipalObj->GrantRight( Right => 'SeeCustomField' );
+
+    my $res = $mech->post_json("$rest_base_path/customfields",
+        [{field => 'LookupType', value => 'RT::Queue-RT::Ticket'}],
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+
+    my $content = $mech->json_response;
+    is($content->{total}, 3);
+    is($content->{count}, 3);
+    my $items = $content->{items};
+    is(scalar(@$items), 3);
+    
+    is($items->[0]->{type}, 'customfield');
+    is($items->[0]->{id}, $freeform_cf->id);
+    like($items->[0]->{_url}, qr{$rest_base_path/customfield/$freeform_cf_id$});
+
+    is($items->[1]->{type}, 'customfield');
+    is($items->[1]->{id}, $select_cf->id);
+    like($items->[1]->{_url}, qr{$rest_base_path/customfield/$select_cf_id$});
+
+    is($items->[2]->{type}, 'customfield');
+    is($items->[2]->{id}, $basedon_cf->id);
+    like($items->[2]->{_url}, qr{$rest_base_path/customfield/$basedon_cf_id$});
+}
+
+# Freeform CustomField display
+{
+    my $res = $mech->get("$rest_base_path/customfield/$freeform_cf_id",
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+    my $content = $mech->json_response;
+    is($content->{id}, $freeform_cf_id);
+    is($content->{Name}, $freeform_cf->Name);
+    is($content->{Description}, '');
+    is($content->{LookupType}, 'RT::Queue-RT::Ticket');
+    is($content->{Type}, 'Freeform');
+    is($content->{MaxValues}, 1);
+    is($content->{Disabled}, 0);
+
+    my @fields = qw(SortOrder Pattern Created Creator LastUpdated LastUpdatedBy);
+    push @fields, qw(UniqueValues EntryHint) if RT::Handle::cmp_version($RT::VERSION, '4.4.0') >= 0;
+    ok(exists $content->{$_}, "got $_") for @fields;
+
+    my $links = $content->{_hyperlinks};
+    is(scalar @$links, 1);
+    is($links->[0]{ref}, 'self');
+    is($links->[0]{id}, $freeform_cf_id);
+    is($links->[0]{type}, 'customfield');
+    like($links->[0]{_url}, qr{$rest_base_path/customfield/$freeform_cf_id$});
+}
+
+# Select CustomField display
+{
+    my $res = $mech->get("$rest_base_path/customfield/$select_cf_id",
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+    my $content = $mech->json_response;
+    is($content->{id}, $select_cf_id);
+    is($content->{Name}, $select_cf->Name);
+    is($content->{Description}, '');
+    is($content->{LookupType}, 'RT::Queue-RT::Ticket');
+    is($content->{Type}, 'Select');
+    is($content->{MaxValues}, 1);
+    is($content->{Disabled}, 0);
+
+    my @fields = qw(SortOrder Pattern Created Creator LastUpdated LastUpdatedBy);
+    push @fields, qw(UniqueValues EntryHint) if RT::Handle::cmp_version($RT::VERSION, '4.4.0') >= 0;
+    ok(exists $content->{$_}, "got $_") for @fields;
+
+    my $links = $content->{_hyperlinks};
+    is(scalar @$links, 1);
+    is($links->[0]{ref}, 'self');
+    is($links->[0]{id}, $select_cf_id);
+    is($links->[0]{type}, 'customfield');
+    like($links->[0]{_url}, qr{$rest_base_path/customfield/$select_cf_id$});
+
+    my $values = $content->{Values};
+    is_deeply($values, ['First Value', 'Second Value', 'Third Value']);
+}
+
+# BasedOn CustomField display
+{
+    my $res = $mech->get("$rest_base_path/customfield/$basedon_cf_id",
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+    my $content = $mech->json_response;
+    is($content->{id}, $basedon_cf_id);
+    is($content->{Name}, $basedon_cf->Name);
+    is($content->{Description}, '');
+    is($content->{LookupType}, 'RT::Queue-RT::Ticket');
+    is($content->{Type}, 'Select');
+    is($content->{MaxValues}, 1);
+    is($content->{Disabled}, 0);
+
+    my @fields = qw(SortOrder Pattern Created Creator LastUpdated LastUpdatedBy);
+    push @fields, qw(UniqueValues EntryHint) if RT::Handle::cmp_version($RT::VERSION, '4.4.0') >= 0;
+    ok(exists $content->{$_}, "got $_") for @fields;
+
+    my $links = $content->{_hyperlinks};
+    is(scalar @$links, 1);
+    is($links->[0]{ref}, 'self');
+    is($links->[0]{id}, $basedon_cf_id);
+    is($links->[0]{type}, 'customfield');
+    like($links->[0]{_url}, qr{$rest_base_path/customfield/$basedon_cf_id$});
+
+    my $values = $content->{Values};
+    is_deeply($values, ['With First Value', 'With No Value']);
+}
+
+# BasedOn CustomField display with category filter
+{
+    my $res = $mech->get("$rest_base_path/customfield/$basedon_cf_id?category=First%20Value",
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+    my $content = $mech->json_response;
+    is($content->{id}, $basedon_cf_id);
+    is($content->{Name}, $basedon_cf->Name);
+    is($content->{Description}, '');
+    is($content->{LookupType}, 'RT::Queue-RT::Ticket');
+    is($content->{Type}, 'Select');
+    is($content->{MaxValues}, 1);
+    is($content->{Disabled}, 0);
+
+    my @fields = qw(SortOrder Pattern Created Creator LastUpdated LastUpdatedBy);
+    push @fields, qw(UniqueValues EntryHint) if RT::Handle::cmp_version($RT::VERSION, '4.4.0') >= 0;
+    ok(exists $content->{$_}, "got $_") for @fields;
+
+    my $links = $content->{_hyperlinks};
+    is(scalar @$links, 1);
+    is($links->[0]{ref}, 'self');
+    is($links->[0]{id}, $basedon_cf_id);
+    is($links->[0]{type}, 'customfield');
+    like($links->[0]{_url}, qr{$rest_base_path/customfield/$basedon_cf_id$});
+
+    my $values = $content->{Values};
+    is_deeply($values, ['With First Value']);
+}
+
+# BasedOn CustomField display with null category filter
+{
+    my $res = $mech->get("$rest_base_path/customfield/$basedon_cf_id?category=",
+        'Authorization' => $auth,
+    );
+    is($res->code, 200);
+    my $content = $mech->json_response;
+    is($content->{id}, $basedon_cf_id);
+    is($content->{Name}, $basedon_cf->Name);
+    is($content->{Description}, '');
+    is($content->{LookupType}, 'RT::Queue-RT::Ticket');
+    is($content->{Type}, 'Select');
+    is($content->{MaxValues}, 1);
+    is($content->{Disabled}, 0);
+
+    my @fields = qw(SortOrder Pattern Created Creator LastUpdated LastUpdatedBy);
+    push @fields, qw(UniqueValues EntryHint) if RT::Handle::cmp_version($RT::VERSION, '4.4.0') >= 0;
+    ok(exists $content->{$_}, "got $_") for @fields;
+
+    my $links = $content->{_hyperlinks};
+    is(scalar @$links, 1);
+    is($links->[0]{ref}, 'self');
+    is($links->[0]{id}, $basedon_cf_id);
+    is($links->[0]{type}, 'customfield');
+    like($links->[0]{_url}, qr{$rest_base_path/customfield/$basedon_cf_id$});
+
+    my $values = $content->{Values};
+    is_deeply($values, ['With No Value']);
+}
+
+done_testing;
+

--- a/t/customfields.t
+++ b/t/customfields.t
@@ -7,44 +7,31 @@ my $mech = RT::Extension::REST2::Test->mech;
 my $auth = RT::Extension::REST2::Test->authorization_header;
 my $rest_base_path = '/REST/2.0';
 my $user = RT::Extension::REST2::Test->user;
+$user->PrincipalObj->GrantRight( Right => 'SeeCustomField' );
 
-my $freeform_cf = RT::CustomField->new(RT->SystemUser);
-$freeform_cf->Create(Name => 'Freeform CF', Type => 'Freeform', MaxValues => 1, Queue => 'General');
-my $freeform_cf_id = $freeform_cf->id;
+my $queue = RT::Queue->new(RT->SystemUser);
+$queue->Load('General');
+my $queue_id = $queue->id;
 
-my $select_cf = RT::CustomField->new(RT->SystemUser);
-$select_cf->Create(Name => 'Select CF', Type => 'Select', MaxValues => 1, Queue => 'General');
-$select_cf->AddValue(Name => 'First Value', SortOder => 0);
-$select_cf->AddValue(Name => 'Second Value', SortOrder => 1);
-$select_cf->AddValue(Name => 'Third Value', SortOrder => 2);
-my $select_cf_id = $select_cf->id;
-my $select_cf_values = $select_cf->Values->ItemsArrayRef;
+my $attached_single_cf = RT::CustomField->new(RT->SystemUser);
+$attached_single_cf->Create(LookupType => 'RT::Queue-RT::Ticket', Name => 'Freeform CF', Type => 'Freeform', MaxValues => 1, Queue => 'General');
+my $attached_single_cf_id = $attached_single_cf->id;
 
-my $basedon_cf = RT::CustomField->new(RT->SystemUser);
-$basedon_cf->Create(Name => 'SubSelect CF', Type => 'Select', MaxValues => 1, Queue => 'General', BasedOn => $select_cf->id);
-$basedon_cf->AddValue(Name => 'With First Value', Category => $select_cf_values->[0]->Name, SortOder => 0);
-$basedon_cf->AddValue(Name => 'With No Value', SortOder => 0);
-my $basedon_cf_id = $basedon_cf->id;
-my $basedon_cf_values = $basedon_cf->Values->ItemsArrayRef;
+my $attached_multiple_cf = RT::CustomField->new(RT->SystemUser);
+$attached_multiple_cf->Create(LookupType => 'RT::Queue-RT::Ticket', Name => 'Freeform CF', Type => 'Freeform', MaxValues => 0, Queue => 'General');
+my $attached_multiple_cf_id = $attached_multiple_cf->id;
 
-# Right test - search all tickets customfields without SeeCustomField
+my $detached_cf = RT::CustomField->new(RT->SystemUser);
+$detached_cf->Create(LookupType => 'RT::Queue-RT::Ticket', Name => 'Freeform CF', Type => 'Freeform', MaxValues => 1);
+my $detached_cf_id = $detached_cf->id;
+
+my $queue_cf = RT::CustomField->new(RT->SystemUser);
+$queue_cf->Create(LookupType => 'RT::Queue', Name => 'Freeform CF', Type => 'Freeform', MaxValues => 1);
+$queue_cf->AddToObject($queue);
+my $queue_cf_id = $queue_cf->id;
+
+# All tickets customfields
 {
-    my $res = $mech->post_json("$rest_base_path/customfields",
-        [{field => 'LookupType', value => 'RT::Queue-RT::Ticket'}],
-        'Authorization' => $auth,
-    );
-    is($res->code, 200);
-
-    my $content = $mech->json_response;
-    is($content->{total}, 3);
-    is($content->{count}, 0);
-    is_deeply($content->{items}, []);
-}
-
-# search all tickets customfields
-{
-    $user->PrincipalObj->GrantRight( Right => 'SeeCustomField' );
-
     my $res = $mech->post_json("$rest_base_path/customfields",
         [{field => 'LookupType', value => 'RT::Queue-RT::Ticket'}],
         'Authorization' => $auth,
@@ -54,167 +41,45 @@ my $basedon_cf_values = $basedon_cf->Values->ItemsArrayRef;
     my $content = $mech->json_response;
     is($content->{total}, 3);
     is($content->{count}, 3);
-    my $items = $content->{items};
-    is(scalar(@$items), 3);
-    
-    is($items->[0]->{type}, 'customfield');
-    is($items->[0]->{id}, $freeform_cf->id);
-    like($items->[0]->{_url}, qr{$rest_base_path/customfield/$freeform_cf_id$});
-
-    is($items->[1]->{type}, 'customfield');
-    is($items->[1]->{id}, $select_cf->id);
-    like($items->[1]->{_url}, qr{$rest_base_path/customfield/$select_cf_id$});
-
-    is($items->[2]->{type}, 'customfield');
-    is($items->[2]->{id}, $basedon_cf->id);
-    like($items->[2]->{_url}, qr{$rest_base_path/customfield/$basedon_cf_id$});
+    is(scalar @{$content->{items}}, 3);
+    my @ids = sort map {$_->{id}} @{$content->{items}};
+    is_deeply(\@ids, [$attached_single_cf_id, $attached_multiple_cf_id, $detached_cf_id]);
 }
 
-# Freeform CustomField display
+# All tickets single customfields attached to queue 'General'
 {
-    my $res = $mech->get("$rest_base_path/customfield/$freeform_cf_id",
+    my $res = $mech->post_json("$rest_base_path/queue/$queue_id/customfields",
+        [
+            {field => 'LookupType', value => 'RT::Queue-RT::Ticket'},
+            {field => 'MaxValues', value => 1},
+        ],
         'Authorization' => $auth,
     );
     is($res->code, 200);
+
     my $content = $mech->json_response;
-    is($content->{id}, $freeform_cf_id);
-    is($content->{Name}, $freeform_cf->Name);
-    is($content->{Description}, '');
-    is($content->{LookupType}, 'RT::Queue-RT::Ticket');
-    is($content->{Type}, 'Freeform');
-    is($content->{MaxValues}, 1);
-    is($content->{Disabled}, 0);
-
-    my @fields = qw(SortOrder Pattern Created Creator LastUpdated LastUpdatedBy);
-    push @fields, qw(UniqueValues EntryHint) if RT::Handle::cmp_version($RT::VERSION, '4.4.0') >= 0;
-    ok(exists $content->{$_}, "got $_") for @fields;
-
-    my $links = $content->{_hyperlinks};
-    is(scalar @$links, 1);
-    is($links->[0]{ref}, 'self');
-    is($links->[0]{id}, $freeform_cf_id);
-    is($links->[0]{type}, 'customfield');
-    like($links->[0]{_url}, qr{$rest_base_path/customfield/$freeform_cf_id$});
+    is($content->{total}, 1);
+    is($content->{count}, 1);
+    is(scalar @{$content->{items}}, 1);
+    is($content->{items}->[0]->{id}, $attached_single_cf_id);
 }
 
-# Select CustomField display
+# All single customfields attached to queue 'General'
 {
-    my $res = $mech->get("$rest_base_path/customfield/$select_cf_id",
+    my $res = $mech->post_json("$rest_base_path/queue/$queue_id/customfields",
+        [
+            {field => 'MaxValues', value => 1},
+        ],
         'Authorization' => $auth,
     );
     is($res->code, 200);
+
     my $content = $mech->json_response;
-    is($content->{id}, $select_cf_id);
-    is($content->{Name}, $select_cf->Name);
-    is($content->{Description}, '');
-    is($content->{LookupType}, 'RT::Queue-RT::Ticket');
-    is($content->{Type}, 'Select');
-    is($content->{MaxValues}, 1);
-    is($content->{Disabled}, 0);
-
-    my @fields = qw(SortOrder Pattern Created Creator LastUpdated LastUpdatedBy);
-    push @fields, qw(UniqueValues EntryHint) if RT::Handle::cmp_version($RT::VERSION, '4.4.0') >= 0;
-    ok(exists $content->{$_}, "got $_") for @fields;
-
-    my $links = $content->{_hyperlinks};
-    is(scalar @$links, 1);
-    is($links->[0]{ref}, 'self');
-    is($links->[0]{id}, $select_cf_id);
-    is($links->[0]{type}, 'customfield');
-    like($links->[0]{_url}, qr{$rest_base_path/customfield/$select_cf_id$});
-
-    my $values = $content->{Values};
-    is_deeply($values, ['First Value', 'Second Value', 'Third Value']);
-}
-
-# BasedOn CustomField display
-{
-    my $res = $mech->get("$rest_base_path/customfield/$basedon_cf_id",
-        'Authorization' => $auth,
-    );
-    is($res->code, 200);
-    my $content = $mech->json_response;
-    is($content->{id}, $basedon_cf_id);
-    is($content->{Name}, $basedon_cf->Name);
-    is($content->{Description}, '');
-    is($content->{LookupType}, 'RT::Queue-RT::Ticket');
-    is($content->{Type}, 'Select');
-    is($content->{MaxValues}, 1);
-    is($content->{Disabled}, 0);
-
-    my @fields = qw(SortOrder Pattern Created Creator LastUpdated LastUpdatedBy);
-    push @fields, qw(UniqueValues EntryHint) if RT::Handle::cmp_version($RT::VERSION, '4.4.0') >= 0;
-    ok(exists $content->{$_}, "got $_") for @fields;
-
-    my $links = $content->{_hyperlinks};
-    is(scalar @$links, 1);
-    is($links->[0]{ref}, 'self');
-    is($links->[0]{id}, $basedon_cf_id);
-    is($links->[0]{type}, 'customfield');
-    like($links->[0]{_url}, qr{$rest_base_path/customfield/$basedon_cf_id$});
-
-    my $values = $content->{Values};
-    is_deeply($values, ['With First Value', 'With No Value']);
-}
-
-# BasedOn CustomField display with category filter
-{
-    my $res = $mech->get("$rest_base_path/customfield/$basedon_cf_id?category=First%20Value",
-        'Authorization' => $auth,
-    );
-    is($res->code, 200);
-    my $content = $mech->json_response;
-    is($content->{id}, $basedon_cf_id);
-    is($content->{Name}, $basedon_cf->Name);
-    is($content->{Description}, '');
-    is($content->{LookupType}, 'RT::Queue-RT::Ticket');
-    is($content->{Type}, 'Select');
-    is($content->{MaxValues}, 1);
-    is($content->{Disabled}, 0);
-
-    my @fields = qw(SortOrder Pattern Created Creator LastUpdated LastUpdatedBy);
-    push @fields, qw(UniqueValues EntryHint) if RT::Handle::cmp_version($RT::VERSION, '4.4.0') >= 0;
-    ok(exists $content->{$_}, "got $_") for @fields;
-
-    my $links = $content->{_hyperlinks};
-    is(scalar @$links, 1);
-    is($links->[0]{ref}, 'self');
-    is($links->[0]{id}, $basedon_cf_id);
-    is($links->[0]{type}, 'customfield');
-    like($links->[0]{_url}, qr{$rest_base_path/customfield/$basedon_cf_id$});
-
-    my $values = $content->{Values};
-    is_deeply($values, ['With First Value']);
-}
-
-# BasedOn CustomField display with null category filter
-{
-    my $res = $mech->get("$rest_base_path/customfield/$basedon_cf_id?category=",
-        'Authorization' => $auth,
-    );
-    is($res->code, 200);
-    my $content = $mech->json_response;
-    is($content->{id}, $basedon_cf_id);
-    is($content->{Name}, $basedon_cf->Name);
-    is($content->{Description}, '');
-    is($content->{LookupType}, 'RT::Queue-RT::Ticket');
-    is($content->{Type}, 'Select');
-    is($content->{MaxValues}, 1);
-    is($content->{Disabled}, 0);
-
-    my @fields = qw(SortOrder Pattern Created Creator LastUpdated LastUpdatedBy);
-    push @fields, qw(UniqueValues EntryHint) if RT::Handle::cmp_version($RT::VERSION, '4.4.0') >= 0;
-    ok(exists $content->{$_}, "got $_") for @fields;
-
-    my $links = $content->{_hyperlinks};
-    is(scalar @$links, 1);
-    is($links->[0]{ref}, 'self');
-    is($links->[0]{id}, $basedon_cf_id);
-    is($links->[0]{type}, 'customfield');
-    like($links->[0]{_url}, qr{$rest_base_path/customfield/$basedon_cf_id$});
-
-    my $values = $content->{Values};
-    is_deeply($values, ['With No Value']);
+    is($content->{total}, 2);
+    is($content->{count}, 2);
+    is(scalar @{$content->{items}}, 2);
+    my @ids = sort map {$_->{id}} @{$content->{items}};
+    is_deeply(\@ids, [$attached_single_cf_id, $queue_cf_id]);
 }
 
 done_testing;


### PR DESCRIPTION
This pull request adds entry points to search for customfields attached to a particular catalog, class or queue. Here are entry points for customfields:

   Custom Fields
        GET /customfields?query=<JSON>
        POST /customfields
            search for custom fields using L</JSON searches> syntax

        GET /catalog/:id/customfields?query=<JSON>
        POST /catalog/:id/customfields
            search for custom fields attached to a catalog using L</JSON searches> syntax

        GET /class/:id/customfields?query=<JSON>
        POST /class/:id/customfields
            search for custom fields attached to a class using L</JSON searches> syntax

        GET /queue/:id/customfields?query=<JSON>
        POST /queue/:id/customfields
            search for custom fields attached to a queue using L</JSON searches> syntax

        GET /customfield/:id
            retrieve a custom field