### PR TITLE
Use showuserhistory acl

### DIFF
--- a/lib/RT/Extension/REST2/Resource/User.pm
+++ b/lib/RT/Extension/REST2/Resource/User.pm
@@ -52,6 +52,7 @@ sub forbidden {
     my $self = shift;
     return 0 if not $self->record->id;
     return 0 if $self->record->id == $self->current_user->id;
+    return 0 if $self->record->CurrentUserHasRight("ShowUserHistory");
     return 0 if $self->record->CurrentUserHasRight("AdminUsers");
     return 1;
 }

--- a/lib/RT/Extension/REST2/Resource/Users.pm
+++ b/lib/RT/Extension/REST2/Resource/Users.pm
@@ -24,6 +24,11 @@ sub searchable_fields {
 
 sub forbidden {
     my $self = shift;
+
+    return 0 if $self->current_user->HasRight(
+        Right => 'ShowUserHistory',
+        Object  => RT->System,
+    );
     return 0 if $self->current_user->HasRight(
         Right   => "AdminUsers",
         Object  => RT->System,


### PR DESCRIPTION
REST2 up to now doesn't allow any user to see other users properties, even there is "ShowUserHistory" granted at global level. This PR allow this. I expect that RT API stil check for any unalllowed access/modifications later. 