### PR TITLE
Set the Subject on the create attachment

### DIFF
--- a/lib/RT/Extension/REST2/Resource/Ticket.pm
+++ b/lib/RT/Extension/REST2/Resource/Ticket.pm
@@ -46,6 +46,7 @@ sub create_record {
     if ( defined $data->{Content} ) {
         $data->{MIMEObj} = HTML::Mason::Commands::MakeMIMEEntity(
             Interface => 'REST',
+            Subject   => $data->{Subject},
             Body      => delete $data->{Content},
             Type      => delete $data->{ContentType} || 'text/plain',
         );

--- a/xt/tickets.t
+++ b/xt/tickets.t
@@ -155,6 +155,22 @@ my ($ticket_url, $ticket_id);
     $user->PrincipalObj->RevokeRight(Right => 'SeeQueue');
 }
 
+# Ticket Create Attachment created correctly
+{
+    my $ticket = RT::Ticket->new($user);
+    $ticket->Load($ticket_id);
+    my $transaction_id = $ticket->Transactions->Last->id;
+    my $attachments = $ticket->Attachments->ItemsArrayRef;
+
+    # 1 attachment
+    is(scalar(@$attachments), 1);
+
+    is($attachments->[0]->Parent, 0);
+    is($attachments->[0]->Subject, 'Ticket creation using REST');
+    ok(!$attachments->[0]->Filename);
+    is($attachments->[0]->ContentType, 'text/plain');
+}
+
 # Ticket Search
 {
     my $res = $mech->get("$rest_base_path/tickets?query=id>0",


### PR DESCRIPTION
Previously the Subject isn't being passed into the MIME Entity which
is create for the Attachment of the create Transaction. This change
makes the REST2 API consistent with the other Create methods.