### PR TITLE
When creating a objects, allow CustomFields to use names.

### DIFF
--- a/lib/RT/Extension/REST2/Resource/Record/Writable.pm
+++ b/lib/RT/Extension/REST2/Resource/Record/Writable.pm
@@ -296,6 +296,10 @@ sub create_record {
     if ($record->isa('RT::Ticket') || $record->isa('RT::Asset')) {
         if ($cfs) {
             while (my ($id, $value) = each(%$cfs)) {
+                if ($id !~ /^\d+$/) {
+                    my $cf = $record->LoadCustomFieldByIdentifier($id);
+                    $id = $cf->Id;
+                }
                 delete $cfs->{$id};
                 $args{"CustomField-$id"} = $value;
             }

--- a/lib/RT/Extension/REST2/Resource/Record/Writable.pm
+++ b/lib/RT/Extension/REST2/Resource/Record/Writable.pm
@@ -290,16 +290,31 @@ sub create_record {
 
     my $cfs = delete $args{CustomFields};
 
+    # Lookup CustomFields by name.
+    if ($cfs) {
+        foreach my $id (keys(%$cfs)) {
+            if ($id !~ /^\d+$/) {
+                my $cf = $record->LoadCustomFieldByIdentifier($id);
+
+                if ($cf->Id) {
+                    $cfs->{$cf->Id} = $cfs->{$id};
+                    delete $cfs->{$id};
+                } else {
+                    # I would really like to return an error message, but, how?
+                    # RT appears to treat missing permission to a CF or
+                    # non-existance of a CF as a non-fatal error.
+                    RT->Logger->error( $record->loc( "Custom field [_1] not found", $id ) );
+                }
+            }
+        }
+    }
+
     # if a record class handles CFs in ->Create, use it (so it doesn't generate
     # spurious transactions and interfere with default values, etc). Otherwise,
     # add OCFVs after ->Create
     if ($record->isa('RT::Ticket') || $record->isa('RT::Asset')) {
         if ($cfs) {
             while (my ($id, $value) = each(%$cfs)) {
-                if ($id !~ /^\d+$/) {
-                    my $cf = $record->LoadCustomFieldByIdentifier($id);
-                    $id = $cf->Id;
-                }
                 delete $cfs->{$id};
                 $args{"CustomField-$id"} = $value;
             }


### PR DESCRIPTION
The docs all show examples of specifying CustomFields by name, yet that doesn't actually work. Let's make it work.
This replaces #14 .