### PR TITLE
Allow to return Requestors and First transaction content in ticket search results

### DIFF
--- a/lib/RT/Extension/REST2/Resource.pm
+++ b/lib/RT/Extension/REST2/Resource.pm
@@ -74,6 +74,10 @@ sub expand_field {
                 $result = $contentObj->Content;
             }
         }
+    } elsif ($field eq 'MergedTickets') {
+        my $method = 'Merged';
+        my @obj = $item->$method;
+        $result = \@obj;
     } elsif ($item->can('_Accessible') && $item->_Accessible($field => 'read')) {
         # RT::Record derived object, so we can check access permissions.
 

--- a/lib/RT/Extension/REST2/Resource.pm
+++ b/lib/RT/Extension/REST2/Resource.pm
@@ -62,7 +62,18 @@ sub expand_field {
 
             push @{ $result }, values %values if %values;
         }
-
+    } elsif ($field eq 'Description' && $item->isa('RT::Ticket')) {
+        my $transactions = $item->Transactions;
+        $transactions->Limit(
+            FIELD => 'Type',
+            VALUE => 'Create'
+        );
+        if ($transactions->Count > 0) {
+            my $contentObj = $transactions->First->ContentObj;
+            if (defined $contentObj) {
+                $result = $contentObj->Content;
+            }
+        }
     } elsif ($item->can('_Accessible') && $item->_Accessible($field => 'read')) {
         # RT::Record derived object, so we can check access permissions.
 
@@ -73,19 +84,40 @@ sub expand_field {
             my $obj = $item->$method;
             if ( $obj->can('UID') and $result = expand_uid( $obj->UID ) ) {
                 my $param_field = $param_prefix . '[' . $field . ']';
-                my @subfields = split( /,/, $self->request->param($param_field) || '' );
-
-                for my $subfield (@subfields) {
-                    my $subfield_result = $self->expand_field( $obj, $subfield, $param_field );
-                    $result->{$subfield} = $subfield_result if defined $subfield_result;
-                }
+                $self->expand_subfield($result, $obj, $param_field);
             }
-        }
+        } elsif ($item->can($field) && defined blessed($item->$field) && $item->$field->isa('RT::Group')) {
+	        my $members = $item->$field->MembersObj;
+            my $param_field = $param_prefix . '[' . $field . ']';
+	        my @objects;
 
+            while (my $member = $members->Next) {
+                my $user = RT::User->new($item->CurrentUser);
+                $user->Load($member->MemberId);
+                my $res = expand_uid($user->UID);
+                $self->expand_subfield($res, $user, $param_field);
+                push(@objects, $res);
+            }
+            $result = \@objects;
+        }
         $result //= $item->$field;
     }
 
     return $result // '';
+}
+
+sub expand_subfield {
+    my $self = shift;
+    my $result = shift;
+    my $obj = shift;
+    my $param_field = shift;
+
+    my @subfields = split( /,/, $self->request->param($param_field) || '' );
+
+    for my $subfield (@subfields) {
+        my $subfield_result = $self->expand_field( $obj, $subfield, $param_field );
+        $result->{$subfield} = $subfield_result if defined $subfield_result;
+    }
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/RT/Extension/REST2/Util.pm
+++ b/lib/RT/Extension/REST2/Util.pm
@@ -165,6 +165,7 @@ sub deserialize_record {
     my $data   = shift;
 
     my $does_roles = $record->DOES("RT::Record::Role::Roles");
+    my $does_links = $record->DOES("RT::Record::Role::Links");
 
     # Sanitize input for the Perl API
     for my $field (sort keys %$data) {
@@ -186,6 +187,11 @@ sub deserialize_record {
                     if looks_like_uid($member);
             }
             $data->{$field} = \@members;
+        }
+        elsif ( $does_links and ($field =~ /^(Add|Delete)Link$/ ) ) {
+            my @links = ref $value eq 'ARRAY'
+                ? @$value : $value;
+            $data->{$field} = \@links;
         }
         else {
             RT->Logger->debug("Received unknown value via JSON for field $field: ".ref($value));


### PR DESCRIPTION
Example:
`http://localhost/REST/2.0/tickets?query=Queue='general'&fields=Requestors,Description&fields[Requestors]=RealName`

```json
{
  "count": 1,
  "total": 1,
  "page": 1,
  "pages": 1,
  "per_page": 20,
  "items": [
    {
      "Requestors": [
        {
          "_url": "http://localhost/REST/2.0/user/root",
          "type": "user",
          "RealName": "Enoch Root",
          "id": "root"
        }
      ],
      "Description": "<p>Test</p>\n",
      "id": "5",
      "_url": "http://localhost/REST/2.0/ticket/5",
      "type": "ticket"
    }
  ]
}

```