### PR TITLE
Fix search using OR aggregator for RT::Users

### DIFF
--- a/lib/RT/Extension/REST2/Resource/Collection/QueryByJSON.pm
+++ b/lib/RT/Extension/REST2/Resource/Collection/QueryByJSON.pm
@@ -63,6 +63,9 @@ sub limit_collection {
             ( $limit->{entry_aggregator}
                 ? (ENTRYAGGREGATOR => $limit->{entry_aggregator})
                 : () ),
+            # Always force a subclause here as some collections such as
+            # RT::Users for example needs it when using an OR entry aggregator
+            SUBCLAUSE => 'json_search',
         );
     }
 


### PR DESCRIPTION
Searching with:
[{"field":"EmailAddress","operator":"=","value":"xxx"},{"field":"Name","operator":"=","value":"xxxx","entry_aggregator": "OR"}]

doesn't works with RT::Users, at least, because this collection has
already default limits on Disabled field and PrincipalType:

   (Principals_1.Disabled = '0') AND (Principals_1.PrincipalType = 'User')

So we need here parenthesis for the user requested query. I make the
subclause unconditionnal as it doesn't hurt simple queries and make
complex queries more robust.